### PR TITLE
[Feature] get blocks function returns an iterator

### DIFF
--- a/src/network/peer.rs
+++ b/src/network/peer.rs
@@ -480,7 +480,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                     }
                                     // Retrieve the requested blocks.
                                     let blocks = match ledger_reader.get_blocks(start_block_height, end_block_height) {
-                                        Ok(blocks) => blocks,
+                                        Ok(blocks) => blocks.filter_map(|block_result| block_result.ok()),
                                         Err(error) => {
                                             // Route a `Failure` to the ledger.
                                             if let Err(error) = ledger_router.send(LedgerRequest::Failure(peer_ip, format!("{}", error))).await {

--- a/src/rpc/rpc_impl.rs
+++ b/src/rpc/rpc_impl.rs
@@ -29,7 +29,7 @@ use snarkvm::{
     utilities::{FromBytes, ToBytes},
 };
 
-use rayon::iter::{ParallelBridge, ParallelIterator};
+use rayon::iter::ParallelIterator;
 use serde_json::Value;
 use time::OffsetDateTime;
 
@@ -81,7 +81,7 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcContext<N, E> {
     async fn get_blocks(&self, start_block_height: u32, end_block_height: u32) -> Result<Vec<Block<N>>, RpcError> {
         let safe_start_height = max(start_block_height, end_block_height.saturating_sub(E::MAXIMUM_BLOCK_REQUEST - 1));
         match self.ledger.get_blocks(safe_start_height, end_block_height) {
-            Ok(blocks_iter) => Ok(blocks_iter.par_bridge().filter_map(|block_result| block_result.ok()).collect()),
+            Ok(blocks_iter) => Ok(blocks_iter.filter_map(|block_result| block_result.ok()).collect()),
             Err(error) => Err(AnyhowError(error)),
         }
     }

--- a/src/rpc/tests.rs
+++ b/src/rpc/tests.rs
@@ -259,6 +259,7 @@ async fn test_get_block() {
     assert_eq!(response, *Testnet2::genesis_block());
 }
 
+// This test Fails or Pass randomly because par_bridge does not guarantees the order of the iterator.
 #[tokio::test]
 async fn test_get_blocks() {
     // Initialize a new temporary directory.

--- a/storage/src/state/tests.rs
+++ b/storage/src/state/tests.rs
@@ -18,7 +18,7 @@ use crate::{
     storage::{rocksdb::RocksDB, Storage},
     LedgerState,
 };
-use rayon::iter::{ParallelBridge, ParallelIterator};
+use rayon::iter::ParallelIterator;
 use snarkvm::dpc::{prelude::*, testnet2::Testnet2};
 
 use rand::{thread_rng, Rng};
@@ -348,7 +348,6 @@ fn test_transaction_fees() {
     assert_eq!(output_record.value(), amount);
 }
 
-// This test Fails or Pass randomly because par_bridge does not garantee the order of the iterator.
 #[test]
 fn test_get_blocks_iterator() {
     // Initialize a new temporary directory.
@@ -367,7 +366,6 @@ fn test_get_blocks_iterator() {
     let blocks_result: Vec<_> = ledger_state
         .get_blocks(0, ledger_state.latest_block_height() + 1)
         .unwrap()
-        .par_bridge()
         .filter_map(|block_result| block_result.ok())
         .collect();
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

We want to change the return type on get_blocks function of the LedgerState to avoid using collect which could lead to memory problems with a great number of blocks.

## Test Plan

- `test_get_blocks_iterator` -> This test asserts that this new implementation get all the blocks from a ledger.

