### PR TITLE
Feature: iterator for get_blocks function

### DIFF
--- a/src/network/peer.rs
+++ b/src/network/peer.rs
@@ -480,7 +480,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                     }
                                     // Retrieve the requested blocks.
                                     let blocks = match ledger_reader.get_blocks(start_block_height, end_block_height) {
-                                        Ok(blocks) => blocks,
+                                        Ok(blocks) => blocks.filter_map(|block_result| block_result.ok()),
                                         Err(error) => {
                                             // Route a `Failure` to the ledger.
                                             if let Err(error) = ledger_router.send(LedgerRequest::Failure(peer_ip, format!("{}", error))).await {

--- a/src/rpc/rpc_impl.rs
+++ b/src/rpc/rpc_impl.rs
@@ -29,7 +29,7 @@ use snarkvm::{
     utilities::{FromBytes, ToBytes},
 };
 
-use rayon::iter::{ParallelBridge, ParallelIterator};
+use rayon::iter::ParallelIterator;
 use serde_json::Value;
 use time::OffsetDateTime;
 
@@ -81,7 +81,7 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcContext<N, E> {
     async fn get_blocks(&self, start_block_height: u32, end_block_height: u32) -> Result<Vec<Block<N>>, RpcError> {
         let safe_start_height = max(start_block_height, end_block_height.saturating_sub(E::MAXIMUM_BLOCK_REQUEST - 1));
         match self.ledger.get_blocks(safe_start_height, end_block_height) {
-            Ok(blocks_iter) => Ok(blocks_iter.par_bridge().filter_map(|block_result| block_result.ok()).collect()),
+            Ok(blocks_iter) => Ok(blocks_iter.filter_map(|block_result| block_result.ok()).collect()),
             Err(error) => Err(AnyhowError(error)),
         }
     }

--- a/src/rpc/tests.rs
+++ b/src/rpc/tests.rs
@@ -259,7 +259,6 @@ async fn test_get_block() {
     assert_eq!(response, *Testnet2::genesis_block());
 }
 
-// This test Fails or Pass randomly because par_bridge does not guarantees the order of the iterator.
 #[tokio::test]
 async fn test_get_blocks() {
     // Initialize a new temporary directory.

--- a/src/rpc/tests.rs
+++ b/src/rpc/tests.rs
@@ -259,6 +259,7 @@ async fn test_get_block() {
     assert_eq!(response, *Testnet2::genesis_block());
 }
 
+// This test Fails or Pass randomly because par_bridge does not guarantees the order of the iterator.
 #[tokio::test]
 async fn test_get_blocks() {
     // Initialize a new temporary directory.

--- a/storage/src/state/tests.rs
+++ b/storage/src/state/tests.rs
@@ -356,8 +356,8 @@ fn test_get_blocks_iterator() {
     // Initialize an empty ledger.
     let ledger_state = LedgerState::open_writer::<RocksDB, _>(directory.clone()).expect("Failed to initialize ledger");
 
-    // Read the test blocks; note: they don't include the genesis block, as it's always available when creating a ledger.
-    // note: the `blocks_100` file was generated on a testnet2 storage using `LedgerState::dump_blocks`.
+    // Read the test blocks;
+    // note: they don't include the genesis block, as it's always available when creating a ledger.
     let test_blocks = fs::read("benches/blocks_1").unwrap_or_else(|_| panic!("Missing the test blocks file"));
     let blocks: Vec<Block<Testnet2>> = bincode::deserialize(&test_blocks).expect("Failed to deserialize a block dump");
 

--- a/storage/src/state/tests.rs
+++ b/storage/src/state/tests.rs
@@ -18,7 +18,7 @@ use crate::{
     storage::{rocksdb::RocksDB, Storage},
     LedgerState,
 };
-use rayon::iter::{ParallelBridge, ParallelIterator};
+use rayon::iter::ParallelIterator;
 use snarkvm::dpc::{prelude::*, testnet2::Testnet2};
 
 use rand::{thread_rng, Rng};
@@ -348,7 +348,6 @@ fn test_transaction_fees() {
     assert_eq!(output_record.value(), amount);
 }
 
-// This test Fails or Pass randomly because par_bridge does not garantee the order of the iterator.
 #[test]
 fn test_get_blocks_iterator() {
     // Initialize a new temporary directory.
@@ -367,7 +366,6 @@ fn test_get_blocks_iterator() {
     let blocks_result: Vec<_> = ledger_state
         .get_blocks(0, ledger_state.latest_block_height() + 1)
         .unwrap()
-        .par_bridge()
         .filter_map(|block_result| block_result.ok())
         .collect();
 

--- a/storage/src/state/tests.rs
+++ b/storage/src/state/tests.rs
@@ -358,7 +358,7 @@ fn test_get_blocks_iterator() {
 
     // Read the test blocks;
     // note: they don't include the genesis block, as it's always available when creating a ledger.
-    let test_blocks = fs::read("benches/blocks_1").unwrap_or_else(|_| panic!("Missing the test blocks file"));
+    let test_blocks = fs::read("benches/blocks_1").expect("Missing the test blocks file");
     let blocks: Vec<Block<Testnet2>> = bincode::deserialize(&test_blocks).expect("Failed to deserialize a block dump");
 
     // Load a test block into the ledger.


### PR DESCRIPTION
## Motivation

Optimize the `get_blocks` function to be faster and avoid using `collect` because of future memory issues with a great number of blocks. I did some benchmarking with Criterion, trying different scenarios and implementations of this function and these were the results.

|                           | 1 Block         | 143 Blocks        | 203 Blocks        | 400 Blocks       |
|:---------------|:------------ | --------------- |:--------------- |:--------------- |
| std-iterator       |  620 ms       | 19.5 s                 | 28 s                  | 54 s                    |
| std-iterator + par_bridge (std + rayon) | 760 ms (+22%) | 21 s (+5%)   | 30.6 s (+10%) | 58.5 s(+9%) |
| Parallel-iterator (rayon)        | 244 ms (-60%) | 5.6 s (-70%) | 8 s (-71%)   | 15 s (-72%)   |

These results are approximations of the real values.
The first implementation returns an Iterator from the std library.
The second returns an iterator from the std library and uses the `par_bridge` function to transform it into a parallel one whenever it's possible (this `par_bridge` function doesn't guarantee to keep the same order of the original iterator as it says in the [documentation](https://docs.rs/rayon/1.0.3/rayon/iter/trait.ParallelBridge.html)).
The third implementation returns a `ParallelIterator` from rayon and uses that directly.
I had the best results using the third implementation, so I went with that.

I encountered a little problem in the `src/network/peer.rs` file, there was a `for` loop and some `async/await` code and I used a `collect` right now to make it work, that is a work in progress and I want to find a way to avoid that and use the `ParallelIterator` without the `collect` and the `for` loop.

Here are the reports and graphics made by Criterion for you to check the results in more detail 
[report.zip](https://github.com/IAvecilla/snarkOS/files/8612334/report.zip)
The report has three directories:
- Get Blocks ParallelIterator Benches
- Get Blocks std-iter + par_bridge Benches
- Get Blocks std-iter Benches

Each one has a directory for each case of benchmarking (1 block, 143 blocks, 203 blocks and 403 blocks).
The report folder inside each case has all the graphics of interest.

## Test Plan

There is a new test `storage/src/tests.rs` named `test_get_blocks_iterator` that checks that this function works properly with a couple of blocks.

